### PR TITLE
PRMT-2773: Add messageId to sendCoreMessage and sendFragmentMessage. …

### DIFF
--- a/src/api/ehr-out/__tests__/send-fragment-message.test.js
+++ b/src/api/ehr-out/__tests__/send-fragment-message.test.js
@@ -114,6 +114,7 @@ describe('ehr out transfers send fragment message', () => {
       conversationId: mockRequestBody.conversationId,
       odsCode: mockRequestBody.odsCode,
       message: 'anything',
+      messageId: mockRequestBody.messageId,
       attachments: mockRequestBody.fragmentMessage.attachments,
       external_attachments: [externalAttachmentWithoutTitle, externalAttachmentWithoutTitle]
     });
@@ -179,6 +180,7 @@ describe('ehr out transfers send fragment message', () => {
       interactionId: COPC_INTERACTION_ID,
       conversationId: missingExternalAttachmentsInFragment.conversationId,
       odsCode: missingExternalAttachmentsInFragment.odsCode,
+      messageId: missingExternalAttachmentsInFragment.messageId,
       message: 'anything',
       attachments: missingExternalAttachmentsInFragment.fragmentMessage.attachments,
       external_attachments: null

--- a/src/api/ehr-out/__tests__/send-fragment-message.test.js
+++ b/src/api/ehr-out/__tests__/send-fragment-message.test.js
@@ -203,7 +203,6 @@ describe('ehr out transfers send fragment message', () => {
       odsCode: missingExternalAttachmentsInFragment.odsCode,
       messageId: missingExternalAttachmentsInFragment.messageId,
       message: 'anything',
-      messageId: missingExternalAttachmentsInFragment.messageId,
       attachments: missingExternalAttachmentsInFragment.fragmentMessage.attachments,
       external_attachments: null
     };

--- a/src/api/ehr-out/send-core-message.js
+++ b/src/api/ehr-out/send-core-message.js
@@ -9,12 +9,13 @@ import { body } from 'express-validator';
 
 export const sendCoreMessageValidation = [
   body('conversationId').isUUID().withMessage("'conversationId' provided is not of type UUID"),
+  body('messageId').isUUID().withMessage('Provided value is not of type UUID'),
   body('odsCode').notEmpty().withMessage('Value has not been provided'),
   body('ehrRequestId').isUUID().withMessage('Provided value is not of type UUID'),
   body('coreEhr').notEmpty().withMessage('Value has not been provided')
 ];
 export const sendCoreMessage = async (req, res) => {
-  const { conversationId, odsCode, coreEhr, ehrRequestId } = req.body;
+  const { conversationId, odsCode, coreEhr, ehrRequestId, messageId } = req.body;
   const { payload, attachments, external_attachments } = coreEhr;
   const interactionId = 'RCMR_IN030000UK06';
   const serviceId = `urn:nhs:names:services:gp2gp:${interactionId}`;
@@ -40,6 +41,7 @@ export const sendCoreMessage = async (req, res) => {
       conversationId,
       odsCode,
       message: updatedEhrCorePayload,
+      messageId,
       attachments,
       external_attachments: external_attachments
         ? removeTitleFromExternalAttachments(external_attachments)

--- a/src/api/ehr-out/send-fragment-message.js
+++ b/src/api/ehr-out/send-fragment-message.js
@@ -33,6 +33,7 @@ export const sendFragmentMessage = async (req, res) => {
       conversationId,
       odsCode: odsCode,
       message: updatedFragmentPayload,
+      messageId,
       attachments: fragmentMessage.attachments,
       external_attachments: fragmentMessage.external_attachments
         ? removeTitleFromExternalAttachments(fragmentMessage.external_attachments)


### PR DESCRIPTION
- Added messageId to the request body of `sendCoreMessage` and `sendFragmentMessage`. Also ensure the messageId is passed to the `sendMessage` method of mhs-outbound-client
- Added test to validate messageId in request body