### PR TITLE
PRMT-2728 re-added attachmentwrangler to send core & fragments

### DIFF
--- a/src/api/ehr-out/__tests__/send-core-message.test.js
+++ b/src/api/ehr-out/__tests__/send-core-message.test.js
@@ -4,8 +4,10 @@ import request from 'supertest';
 import { v4 } from '../../../__mocks__/uuid';
 import app from '../../../app';
 import { sendMessage } from '../../../services/mhs/mhs-outbound-client';
-import {removeTitleFromExternalAttachments, wrangleAttachments} from '../../../services/mhs/mhs-attachments-wrangler';
-import {jsonEhrExtract} from "../../health-record-transfers/__tests__/data/json-formatted-ehr-example";
+import {
+  removeTitleFromExternalAttachments,
+  wrangleAttachments
+} from '../../../services/mhs/mhs-attachments-wrangler';
 
 jest.mock('../../../services/fhir/sds-fhir-client');
 jest.mock('../../../services/parser/message/update-extract-for-sending');

--- a/src/api/ehr-out/__tests__/send-core-message.test.js
+++ b/src/api/ehr-out/__tests__/send-core-message.test.js
@@ -273,6 +273,10 @@ describe('ehr out transfers', () => {
 
     // when
     updateExtractForSending.mockReturnValue('payload');
+    wrangleAttachments.mockReturnValue({
+      attachments: missingExternalAttachmentsInCore.coreEhr.attachments,
+      external_attachments: null
+    });
 
     const res = await request(app)
       .post('/ehr-out-transfers/core')

--- a/src/api/ehr-out/__tests__/send-fragment-message.test.js
+++ b/src/api/ehr-out/__tests__/send-fragment-message.test.js
@@ -206,6 +206,10 @@ describe('ehr out transfers send fragment message', () => {
     };
 
     updateFragmentForSending.mockReturnValue(expectedMessage.message);
+    wrangleAttachments.mockReturnValue({
+      attachments: missingExternalAttachmentsInFragment.fragmentMessage.attachments,
+      external_attachments: null
+    });
 
     // when
     const res = await request(app)

--- a/src/api/ehr-out/send-core-message.js
+++ b/src/api/ehr-out/send-core-message.js
@@ -4,7 +4,7 @@ import { logError } from '../../middleware/logging';
 import { updateExtractForSending } from '../../services/parser/message/update-extract-for-sending';
 import { initializeConfig } from '../../config/index';
 import { sendMessage } from '../../services/mhs/mhs-outbound-client';
-import { removeTitleFromExternalAttachments } from '../../services/mhs/mhs-attachments-wrangler';
+import {removeTitleFromExternalAttachments, wrangleAttachments} from '../../services/mhs/mhs-attachments-wrangler';
 import { body } from 'express-validator';
 
 export const sendCoreMessageValidation = [
@@ -15,7 +15,7 @@ export const sendCoreMessageValidation = [
 ];
 export const sendCoreMessage = async (req, res) => {
   const { conversationId, odsCode, coreEhr, ehrRequestId } = req.body;
-  const { payload, attachments, external_attachments } = coreEhr;
+  const { payload } = coreEhr;
   const interactionId = 'RCMR_IN030000UK06';
   const serviceId = `urn:nhs:names:services:gp2gp:${interactionId}`;
   const repositoryOdsCode = initializeConfig().deductionsOdsCode;
@@ -34,6 +34,8 @@ export const sendCoreMessage = async (req, res) => {
       receivingPracticeAsid,
       repositoryOdsCode
     );
+
+    const { attachments, external_attachments } = await wrangleAttachments(coreEhr);
 
     await sendMessage({
       interactionId,

--- a/src/api/ehr-out/send-core-message.js
+++ b/src/api/ehr-out/send-core-message.js
@@ -4,7 +4,10 @@ import { logError } from '../../middleware/logging';
 import { updateExtractForSending } from '../../services/parser/message/update-extract-for-sending';
 import { initializeConfig } from '../../config/index';
 import { sendMessage } from '../../services/mhs/mhs-outbound-client';
-import {removeTitleFromExternalAttachments, wrangleAttachments} from '../../services/mhs/mhs-attachments-wrangler';
+import {
+  removeTitleFromExternalAttachments,
+  wrangleAttachments
+} from '../../services/mhs/mhs-attachments-wrangler';
 import { body } from 'express-validator';
 
 export const sendCoreMessageValidation = [

--- a/src/api/ehr-out/send-fragment-message.js
+++ b/src/api/ehr-out/send-fragment-message.js
@@ -3,7 +3,10 @@ import { setCurrentSpanAttributes } from '../../config/tracing';
 import { getPracticeAsid } from '../../services/fhir/sds-fhir-client';
 import { updateFragmentForSending } from '../../services/parser/message/update-fragment-for-sending';
 import { sendMessage } from '../../services/mhs/mhs-outbound-client';
-import { removeTitleFromExternalAttachments } from '../../services/mhs/mhs-attachments-wrangler';
+import {
+  removeTitleFromExternalAttachments,
+  wrangleAttachments
+} from '../../services/mhs/mhs-attachments-wrangler';
 import { logError } from '../../middleware/logging';
 
 export const sendFragmentMessageValidation = [
@@ -28,14 +31,16 @@ export const sendFragmentMessage = async (req, res) => {
       odsCode
     );
 
+    const { attachments, external_attachments } = await wrangleAttachments(fragmentMessage);
+
     await sendMessage({
       interactionId: COPC_INTERACTION_ID,
       conversationId,
       odsCode: odsCode,
       message: updatedFragmentPayload,
-      attachments: fragmentMessage.attachments,
-      external_attachments: fragmentMessage.external_attachments
-        ? removeTitleFromExternalAttachments(fragmentMessage.external_attachments)
+      attachments,
+      external_attachments: external_attachments
+        ? removeTitleFromExternalAttachments(external_attachments)
         : null
     });
 


### PR DESCRIPTION
The MHS adaptor was failing due to the 'content_id' field being unrecognised. The attachmentwrangler used to remove this field and we believe that it needs to be reintroduced for this function.