### PR TITLE
PRMT-2728 fix lower case message ids

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "printWidth": 100,
   "trailingComma": "none",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "endOfLine":"auto"
 }

--- a/src/api/ehr-out/__tests__/send-fragment-message.test.js
+++ b/src/api/ehr-out/__tests__/send-fragment-message.test.js
@@ -39,7 +39,7 @@ const externalAttachmentWithoutTitle = {
 const mockRequestBody = {
   conversationId: conversationId,
   odsCode: 'testOdsCode',
-  messageId: v4(),
+  messageId: v4().toUpperCase(),
   fragmentMessage: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -51,7 +51,7 @@ const mockRequestBody = {
 const mockRequestBodyWithMissingPayload = {
   conversationId: conversationId,
   odsCode: 'testOdsCode',
-  messageId: v4(),
+  messageId: v4().toUpperCase(),
   fragmentMessage: {
     ebXML: 'ebxml',
     attachments: [[{ message_id: '1234' }]],
@@ -61,7 +61,7 @@ const mockRequestBodyWithMissingPayload = {
 
 const missingExternalAttachmentsInFragment = {
   conversationId: v4(),
-  messageId: v4(),
+  messageId: v4().toUpperCase(),
   odsCode: 'ods-code',
   fragmentMessage: {
     ebXML: 'ebxml',
@@ -135,6 +135,7 @@ describe('ehr out transfers send fragment message', () => {
       conversationId: mockRequestBody.conversationId,
       odsCode: mockRequestBody.odsCode,
       message: 'anything',
+      messageId: mockRequestBody.messageId,
       attachments: mockRequestBody.fragmentMessage.attachments,
       external_attachments: [externalAttachmentWithoutTitle, externalAttachmentWithoutTitle]
     });
@@ -201,6 +202,7 @@ describe('ehr out transfers send fragment message', () => {
       conversationId: missingExternalAttachmentsInFragment.conversationId,
       odsCode: missingExternalAttachmentsInFragment.odsCode,
       message: 'anything',
+      messageId: missingExternalAttachmentsInFragment.messageId,
       attachments: missingExternalAttachmentsInFragment.fragmentMessage.attachments,
       external_attachments: null
     };

--- a/src/api/ehr-out/send-fragment-message.js
+++ b/src/api/ehr-out/send-fragment-message.js
@@ -20,7 +20,10 @@ export const sendFragmentMessage = async (req, res) => {
   try {
     const COPC_INTERACTION_ID = 'COPC_IN000001UK01';
     const serviceId = `urn:nhs:names:services:gp2gp:${COPC_INTERACTION_ID}`;
-    const { conversationId, odsCode, messageId, fragmentMessage } = req.body;
+    const { conversationId, odsCode, fragmentMessage } = req.body;
+    let { messageId } = req.body;
+    messageId = messageId.toUpperCase();
+
     setCurrentSpanAttributes(conversationId);
 
     const receivingPractiseAsid = await getPracticeAsid(odsCode, serviceId);
@@ -38,6 +41,7 @@ export const sendFragmentMessage = async (req, res) => {
       conversationId,
       odsCode: odsCode,
       message: updatedFragmentPayload,
+      messageId,
       attachments,
       external_attachments: external_attachments
         ? removeTitleFromExternalAttachments(external_attachments)


### PR DESCRIPTION
[Addressed the issue of message ids being lower case when sent out from GP2GP messenger, which could possibly be the cause of "Large Message general failure" in MCCI_IN010000UK13.