### PR TITLE
[PRMT-3275-BUGFIX] Whitespace trimming

### DIFF
--- a/src/services/parser/message/utilities/__tests__/message-utilities.test.js
+++ b/src/services/parser/message/utilities/__tests__/message-utilities.test.js
@@ -14,6 +14,19 @@ describe('message-utilities', () => {
     expect(xmlStringAfterRebuild).toEqual(inputXml);
   });
 
+  it('should keep leading and trailing whitespaces in tags unchanged', async () => {
+    // given
+    const inputXml =
+      '<text>     Drinking status on eventdate: &#10;&#10;&#10;   &#13;&#10; Current drinker    </text>';
+
+    // when
+    const jsObjectAfterParse = xmlStringToJsObject(inputXml);
+    const xmlStringAfterRebuild = jsObjectToXmlString(jsObjectAfterParse);
+
+    // then
+    expect(xmlStringAfterRebuild).toEqual(inputXml);
+  });
+
   it('should keep escaped greater than (>) and less than (<) symbols unchanged', async () => {
     // given
     const inputXml =

--- a/src/services/parser/message/utilities/message-utilities.js
+++ b/src/services/parser/message/utilities/message-utilities.js
@@ -4,6 +4,7 @@ export const xmlStringToJsObject = xmlString => {
   return new XMLParser({
     processEntities: false,
     ignoreAttributes: false,
+    trimValues: false,
     numberParseOptions: {
       leadingZeros: false
     }


### PR DESCRIPTION
- Fix an issue during xml parsing that trims off trailing and leading whitespaces