### PR TITLE
PRMT-3554 Update dest ODS code before send out ehr-core

### DIFF
--- a/src/api/ehr-out/__tests__/send-core-message.test.js
+++ b/src/api/ehr-out/__tests__/send-core-message.test.js
@@ -22,7 +22,7 @@ jest.mock('../../../config', () => ({
 
 const authKey = 'correct-key';
 const conversationId = v4();
-const destinationOdsCode = 'destination_ods_code'
+const destinationOdsCode = 'destination_ods_code';
 
 const externalAttachmentWithTitle = {
   message_id: '5678',

--- a/src/api/ehr-out/__tests__/send-core-message.test.js
+++ b/src/api/ehr-out/__tests__/send-core-message.test.js
@@ -16,12 +16,13 @@ jest.mock('../../../services/mhs/mhs-attachments-wrangler');
 jest.mock('../../../config', () => ({
   initializeConfig: jest.fn().mockReturnValue({
     consumerApiKeys: { TEST_USER: 'correct-key' },
-    deductionsOdsCode: 'test_odscode'
+    deductionsOdsCode: 'repo_ods_code'
   })
 }));
 
 const authKey = 'correct-key';
 const conversationId = v4();
+const destinationOdsCode = 'destination_ods_code'
 
 const externalAttachmentWithTitle = {
   message_id: '5678',
@@ -38,7 +39,7 @@ const externalAttachmentWithoutTitle = {
 
 const mockRequestBodyWithMissingPayload = {
   conversationId: conversationId,
-  odsCode: 'testOdsCode',
+  odsCode: destinationOdsCode,
   ehrRequestId: v4(),
   messageId: v4(),
   coreEhr: 'core ehr stored in ehr repository'
@@ -46,7 +47,7 @@ const mockRequestBodyWithMissingPayload = {
 
 const mockRequestBody = {
   conversationId: conversationId,
-  odsCode: 'testOdsCode',
+  odsCode: destinationOdsCode,
   ehrRequestId: v4(),
   messageId: v4(),
   coreEhr: {
@@ -61,7 +62,7 @@ const invalidConversationId = {
   conversationId: 'not-uuid',
   ehrRequestId: v4(),
   messageId: v4(),
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -73,7 +74,7 @@ const invalidEhrRequestId = {
   conversationId: v4(),
   ehrRequestId: 'ehrRequestId',
   messageId: v4(),
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -85,7 +86,7 @@ const invalidMessageId = {
   conversationId: v4(),
   ehrRequestId: v4(),
   messageId: 'INVALID-MESSAGE-ID',
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -98,7 +99,7 @@ const missingCoreEhr = {
   conversationId: v4(),
   ehrRequestId: v4(),
   messageId: v4(),
-  odsCode: 'ods-code'
+  odsCode: destinationOdsCode
 };
 
 const missingOdsCode = {
@@ -117,7 +118,7 @@ const missingExternalAttachmentsInCore = {
   conversationId: v4(),
   ehrRequestId: v4(),
   messageId: v4(),
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -126,7 +127,7 @@ const missingExternalAttachmentsInCore = {
 };
 
 describe('ehr out transfers', () => {
-  const odsCode = 'testOdsCode';
+  const odsCode = destinationOdsCode;
   const interactionId = 'RCMR_IN030000UK06';
   const serviceId = `urn:nhs:names:services:gp2gp:${interactionId}`;
   it('should call getPracticeAsid', async () => {
@@ -179,7 +180,8 @@ describe('ehr out transfers', () => {
       mockRequestBody.coreEhr.payload,
       mockRequestBody.ehrRequestId,
       'mockAsid',
-      'test_odscode'
+      'repo_ods_code',
+      destinationOdsCode
     );
 
     expect(wrangleAttachments).toHaveBeenCalledWith(mockRequestBody.coreEhr);
@@ -189,7 +191,7 @@ describe('ehr out transfers', () => {
       interactionId: 'RCMR_IN030000UK06',
       messageId: mockRequestBody.messageId,
       message: 'payload',
-      odsCode: 'testOdsCode',
+      odsCode: destinationOdsCode,
       attachments: mockRequestBody.coreEhr.attachments,
       external_attachments: [externalAttachmentWithoutTitle, externalAttachmentWithoutTitle]
     });
@@ -214,7 +216,7 @@ describe('ehr out transfers', () => {
       interactionId: 'RCMR_IN030000UK06',
       message: 'payload',
       messageId: mockRequestBody.messageId,
-      odsCode: 'testOdsCode',
+      odsCode: destinationOdsCode,
       attachments: mockRequestBody.coreEhr.attachments,
       external_attachments: [externalAttachmentWithoutTitle, externalAttachmentWithoutTitle]
     });

--- a/src/api/ehr-out/send-core-message.js
+++ b/src/api/ehr-out/send-core-message.js
@@ -36,7 +36,8 @@ export const sendCoreMessage = async (req, res) => {
       payload,
       ehrRequestId,
       receivingPracticeAsid,
-      repositoryOdsCode
+      repositoryOdsCode,
+      odsCode
     );
 
     const { attachments, external_attachments } = await wrangleAttachments(coreEhr);

--- a/src/services/parser/message/__tests__/data/templateEhrExtract
+++ b/src/services/parser/message/__tests__/data/templateEhrExtract
@@ -49,7 +49,7 @@
                 <destination typeCode="DST">
                     <AgentOrgSDS classCode="AGNT">
                         <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
-                            <id extension="C88653" root="1.2.826.0.1285.0.1.10"/>
+                            <id extension="${destOdsCode}" root="1.2.826.0.1285.0.1.10"/>
                         </agentOrganizationSDS>
                     </AgentOrgSDS>
                 </destination>

--- a/src/services/parser/message/__tests__/update-extract-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-extract-for-sending.test.js
@@ -13,10 +13,9 @@ describe('updateExtractForSending', () => {
   const OLD_DEST_ODS_CODE = 'OLD-DESTINATION-ODS-CODE';
 
   const NEW_SENDING_ASID = '200000001161';
-  const NEW_RECEIVING_ASID = '200000001162'
+  const NEW_RECEIVING_ASID = '200000001162';
   const NEW_AUTHOR_ODS_CODE = 'NEW-AUTHOR-ODS-CODE';
   const NEW_DEST_ODS_CODE = 'NEW-DESTINATION-ODS-CODE';
-
 
   const templateEhrExtract = (
     receivingAsid,

--- a/src/services/parser/message/__tests__/update-extract-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-extract-for-sending.test.js
@@ -8,18 +8,21 @@ export const templateEhrExtract = (
   receivingAsid,
   sendingAsid,
   priorEhrRequestId,
-  authorOdsCode
+  authorOdsCode,
+  destOdsCode
 ) => {
   const template = readFileSync(path.join(__dirname, 'data', 'templateEhrExtract'), 'utf-8');
   return template
     .replaceAll('${receivingAsid}', receivingAsid)
     .replaceAll('${sendingAsid}', sendingAsid)
     .replaceAll('${priorEhrRequestId}', priorEhrRequestId)
-    .replaceAll('${authorOdsCode}', authorOdsCode);
+    .replaceAll('${authorOdsCode}', authorOdsCode)
+    .replaceAll('${destOdsCode}', destOdsCode);
 };
 
 describe('updateExtractForSending', () => {
   it('should use the new ehr request id, sending asid and receiving asid - as well as overriding author with sending ods code as TPP uses it for COPC continue message destination', async () => {
+    // given
     const oldSendingAsid = '200000000149';
     const oldReceivingAsid = '200000001161';
     const oldEhrRequestId = 'BBBBA01A-A9D1-A411-F824-9F7A00A33757';
@@ -27,7 +30,8 @@ describe('updateExtractForSending', () => {
       oldReceivingAsid,
       oldSendingAsid,
       oldEhrRequestId,
-      'some-old-author-ods-code'
+      'old-author-ods-code',
+      'old-destination-ods-code'
     );
 
     const newSendingAsid = '200000001161';
@@ -37,16 +41,20 @@ describe('updateExtractForSending', () => {
       newReceivingAsid,
       newSendingAsid,
       ehrRequestId,
-      'sending-ods-code'
+      'sending-ods-code',
+      'destination-ods-code'
     );
 
+    // when
     const newEhrExtract = await updateExtractForSending(
       originalEhrExtract,
       ehrRequestId,
       newReceivingAsid,
-      'sending-ods-code'
+      'sending-ods-code',
+      'destination-ods-code'
     );
 
+    // then
     const parsedNewEhrExtract = await new XmlParser().parse(newEhrExtract);
     const parsedExpectedEhrExtract = await new XmlParser().parse(expectedEhrExtract);
     expect(parsedNewEhrExtract).toEqual(parsedExpectedEhrExtract);
@@ -61,7 +69,8 @@ describe('updateExtractForSending', () => {
       oldReceivingAsid,
       oldSendingAsid,
       oldEhrRequestId,
-      'some-old-author-ods-code'
+      'old-author-ods-code',
+      'old-destination-ods-code'
     );
 
     // manually add some escaped special characters to the ehr extract
@@ -79,7 +88,8 @@ describe('updateExtractForSending', () => {
       ehrExtractWithSpecialChars,
       ehrRequestId,
       newReceivingAsid,
-      'sending-ods-code'
+      'sending-ods-code',
+      'destination-ods-code'
     );
 
     expect(newEhrExtract.includes(replacedText)).toBe(true);

--- a/src/services/parser/message/__tests__/update-extract-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-extract-for-sending.test.js
@@ -4,54 +4,65 @@ import * as path from 'path';
 import { v4 } from 'uuid';
 import { XmlParser } from '../../xml-parser/xml-parser';
 
-export const templateEhrExtract = (
-  receivingAsid,
-  sendingAsid,
-  priorEhrRequestId,
-  authorOdsCode,
-  destOdsCode
-) => {
-  const template = readFileSync(path.join(__dirname, 'data', 'templateEhrExtract'), 'utf-8');
-  return template
-    .replaceAll('${receivingAsid}', receivingAsid)
-    .replaceAll('${sendingAsid}', sendingAsid)
-    .replaceAll('${priorEhrRequestId}', priorEhrRequestId)
-    .replaceAll('${authorOdsCode}', authorOdsCode)
-    .replaceAll('${destOdsCode}', destOdsCode);
-};
-
 describe('updateExtractForSending', () => {
+  // Constants for test
+  const OLD_RECEIVING_ASID = '200000001161';
+  const OLD_SENDING_ASID = '200000000149';
+  const OLD_EHR_REQUEST_ID = v4();
+  const OLD_AUTHOR_ODS_CODE = 'OLD-AUTHOR-ODS-CODE';
+  const OLD_DEST_ODS_CODE = 'OLD-DESTINATION-ODS-CODE';
+
+  const NEW_SENDING_ASID = '200000001161';
+  const NEW_RECEIVING_ASID = '200000001162'
+  const NEW_AUTHOR_ODS_CODE = 'NEW-AUTHOR-ODS-CODE';
+  const NEW_DEST_ODS_CODE = 'NEW-DESTINATION-ODS-CODE';
+
+
+  const templateEhrExtract = (
+    receivingAsid,
+    sendingAsid,
+    priorEhrRequestId,
+    authorOdsCode,
+    destOdsCode
+  ) => {
+    const template = readFileSync(path.join(__dirname, 'data', 'templateEhrExtract'), 'utf-8');
+    return template
+      .replaceAll('${receivingAsid}', receivingAsid)
+      .replaceAll('${sendingAsid}', sendingAsid)
+      .replaceAll('${priorEhrRequestId}', priorEhrRequestId)
+      .replaceAll('${authorOdsCode}', authorOdsCode)
+      .replaceAll('${destOdsCode}', destOdsCode);
+  };
+  const buildInputEhrExtract = () => {
+    return templateEhrExtract(
+      OLD_RECEIVING_ASID,
+      OLD_SENDING_ASID,
+      OLD_EHR_REQUEST_ID,
+      OLD_AUTHOR_ODS_CODE,
+      OLD_DEST_ODS_CODE
+    );
+  };
+
   it('should use the new ehr request id, sending asid and receiving asid - as well as overriding author with sending ods code as TPP uses it for COPC continue message destination', async () => {
     // given
-    const oldSendingAsid = '200000000149';
-    const oldReceivingAsid = '200000001161';
-    const oldEhrRequestId = 'BBBBA01A-A9D1-A411-F824-9F7A00A33757';
-    const originalEhrExtract = templateEhrExtract(
-      oldReceivingAsid,
-      oldSendingAsid,
-      oldEhrRequestId,
-      'old-author-ods-code',
-      'old-destination-ods-code'
-    );
-
-    const newSendingAsid = '200000001161';
-    const newReceivingAsid = '200000001162';
+    const originalEhrExtract = buildInputEhrExtract();
     const ehrRequestId = v4();
+
     const expectedEhrExtract = templateEhrExtract(
-      newReceivingAsid,
-      newSendingAsid,
+      NEW_RECEIVING_ASID,
+      NEW_SENDING_ASID,
       ehrRequestId,
-      'sending-ods-code',
-      'destination-ods-code'
+      NEW_AUTHOR_ODS_CODE,
+      NEW_DEST_ODS_CODE
     );
 
     // when
     const newEhrExtract = await updateExtractForSending(
       originalEhrExtract,
       ehrRequestId,
-      newReceivingAsid,
-      'sending-ods-code',
-      'destination-ods-code'
+      NEW_RECEIVING_ASID,
+      NEW_AUTHOR_ODS_CODE,
+      NEW_DEST_ODS_CODE
     );
 
     // then
@@ -62,16 +73,7 @@ describe('updateExtractForSending', () => {
 
   it('should keep escaped special characters (linebreak, apostrophes, quotation marks) unchanged', async () => {
     // given
-    const oldSendingAsid = '200000000149';
-    const oldReceivingAsid = '200000001161';
-    const oldEhrRequestId = 'BBBBA01A-A9D1-A411-F824-9F7A00A33757';
-    const originalEhrExtract = templateEhrExtract(
-      oldReceivingAsid,
-      oldSendingAsid,
-      oldEhrRequestId,
-      'old-author-ods-code',
-      'old-destination-ods-code'
-    );
+    const originalEhrExtract = buildInputEhrExtract();
 
     // manually add some escaped special characters to the ehr extract
     const replacedText =
@@ -80,18 +82,19 @@ describe('updateExtractForSending', () => {
       'Drinking status on eventdate: Current drinker',
       replacedText
     );
-
-    const newReceivingAsid = '200000001162';
     const ehrRequestId = v4();
 
+    // when
     const newEhrExtract = await updateExtractForSending(
       ehrExtractWithSpecialChars,
       ehrRequestId,
-      newReceivingAsid,
-      'sending-ods-code',
-      'destination-ods-code'
+      NEW_RECEIVING_ASID,
+      NEW_AUTHOR_ODS_CODE,
+      NEW_DEST_ODS_CODE
     );
 
+    // then
+    // expect that the special chars are still in the updated ehr extract
     expect(newEhrExtract.includes(replacedText)).toBe(true);
   });
 });

--- a/src/services/parser/message/update-extract-for-sending.js
+++ b/src/services/parser/message/update-extract-for-sending.js
@@ -28,7 +28,10 @@ export const updateExtractForSending = async (
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract, sendingOdsCode);
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract.component.ehrFolder, sendingOdsCode);
 
-  updateIdExtension(controlActEvent.subject.EhrExtract.destination.AgentOrgSDS.agentOrganizationSDS, destinationOdsCode)
+  updateIdExtension(
+    controlActEvent.subject.EhrExtract.destination.AgentOrgSDS.agentOrganizationSDS,
+    destinationOdsCode
+  );
 
   return jsObjectToXmlString(parsedEhr);
 };

--- a/src/services/parser/message/update-extract-for-sending.js
+++ b/src/services/parser/message/update-extract-for-sending.js
@@ -9,7 +9,8 @@ export const updateExtractForSending = async (
   ehrExtract,
   ehrRequestId,
   receivingAsid,
-  sendingOdsCode
+  sendingOdsCode,
+  destinationOdsCode
 ) => {
   const config = initializeConfig();
   const parsedEhr = await xmlStringToJsObject(ehrExtract);
@@ -26,6 +27,8 @@ export const updateExtractForSending = async (
 
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract, sendingOdsCode);
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract.component.ehrFolder, sendingOdsCode);
+
+  updateIdExtension(controlActEvent.subject.EhrExtract.destination.AgentOrgSDS.agentOrganizationSDS, destinationOdsCode)
 
   return jsObjectToXmlString(parsedEhr);
 };


### PR DESCRIPTION
- Amend `updateExtractForSending` to also update destination ODS code 
(Before this PR, it update the sender ASID code, destination ASID code and sender ODS code, but not the destination ODS code)
- Modify existing test to check that destination ODS code is updated
- Refactor the unit test for DRY