### PR TITLE
PRMT-3554 Update dest ODS code before send out ehr-core

### DIFF
--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -12,7 +12,7 @@ jest.mock('../config/logging');
 jest.mock('../config/', () => ({
   initializeConfig: jest.fn().mockReturnValue({
     pdsAsid: 'pdsAsid',
-    deductionsAsid: 'deductionsAsid',
+    repoAsid: 'repoAsid',
     nhsNumberPrefix: '944',
     spineOrgCode: 'code'
   })

--- a/src/api/ehr-out/__tests__/send-core-message.test.js
+++ b/src/api/ehr-out/__tests__/send-core-message.test.js
@@ -22,7 +22,7 @@ jest.mock('../../../config', () => ({
 
 const authKey = 'correct-key';
 const conversationId = v4();
-const destinationOdsCode = 'destination_ods_code'
+const destinationOdsCode = 'destination_ods_code';
 
 const externalAttachmentWithTitle = {
   message_id: '5678',

--- a/src/api/ehr-out/__tests__/send-core-message.test.js
+++ b/src/api/ehr-out/__tests__/send-core-message.test.js
@@ -16,12 +16,13 @@ jest.mock('../../../services/mhs/mhs-attachments-wrangler');
 jest.mock('../../../config', () => ({
   initializeConfig: jest.fn().mockReturnValue({
     consumerApiKeys: { TEST_USER: 'correct-key' },
-    deductionsOdsCode: 'test_odscode'
+    deductionsOdsCode: 'repo_ods_code'
   })
 }));
 
 const authKey = 'correct-key';
 const conversationId = v4();
+const destinationOdsCode = 'destination_ods_code'
 
 const externalAttachmentWithTitle = {
   message_id: '5678',
@@ -38,7 +39,7 @@ const externalAttachmentWithoutTitle = {
 
 const mockRequestBodyWithMissingPayload = {
   conversationId: conversationId,
-  odsCode: 'testOdsCode',
+  odsCode: destinationOdsCode,
   ehrRequestId: v4(),
   messageId: v4(),
   coreEhr: 'core ehr stored in ehr repository'
@@ -46,7 +47,7 @@ const mockRequestBodyWithMissingPayload = {
 
 const mockRequestBody = {
   conversationId: conversationId,
-  odsCode: 'testOdsCode',
+  odsCode: destinationOdsCode,
   ehrRequestId: v4(),
   messageId: v4(),
   coreEhr: {
@@ -61,7 +62,7 @@ const invalidConversationId = {
   conversationId: 'not-uuid',
   ehrRequestId: v4(),
   messageId: v4(),
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -73,7 +74,7 @@ const invalidEhrRequestId = {
   conversationId: v4(),
   ehrRequestId: 'ehrRequestId',
   messageId: v4(),
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -85,7 +86,7 @@ const invalidMessageId = {
   conversationId: v4(),
   ehrRequestId: v4(),
   messageId: 'INVALID-MESSAGE-ID',
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -98,7 +99,7 @@ const missingCoreEhr = {
   conversationId: v4(),
   ehrRequestId: v4(),
   messageId: v4(),
-  odsCode: 'ods-code'
+  odsCode: destinationOdsCode
 };
 
 const missingOdsCode = {
@@ -117,7 +118,7 @@ const missingExternalAttachmentsInCore = {
   conversationId: v4(),
   ehrRequestId: v4(),
   messageId: v4(),
-  odsCode: 'ods-code',
+  odsCode: destinationOdsCode,
   coreEhr: {
     ebXML: 'ebxml',
     payload: 'payload',
@@ -126,7 +127,7 @@ const missingExternalAttachmentsInCore = {
 };
 
 describe('ehr out transfers', () => {
-  const odsCode = 'testOdsCode';
+  const odsCode = destinationOdsCode;
   const interactionId = 'RCMR_IN030000UK06';
   const serviceId = `urn:nhs:names:services:gp2gp:${interactionId}`;
   it('should call getPracticeAsid', async () => {
@@ -179,7 +180,8 @@ describe('ehr out transfers', () => {
       mockRequestBody.coreEhr.payload,
       mockRequestBody.ehrRequestId,
       'mockAsid',
-      'test_odscode'
+      'repo_ods_code',
+      destinationOdsCode
     );
 
     expect(wrangleAttachments).toHaveBeenCalledWith(mockRequestBody.coreEhr);
@@ -189,7 +191,7 @@ describe('ehr out transfers', () => {
       interactionId: 'RCMR_IN030000UK06',
       messageId: mockRequestBody.messageId,
       message: 'payload',
-      odsCode: 'testOdsCode',
+      odsCode: destinationOdsCode,
       attachments: mockRequestBody.coreEhr.attachments,
       external_attachments: [externalAttachmentWithoutTitle, externalAttachmentWithoutTitle]
     });
@@ -214,7 +216,7 @@ describe('ehr out transfers', () => {
       interactionId: 'RCMR_IN030000UK06',
       message: 'payload',
       messageId: mockRequestBody.messageId,
-      odsCode: 'testOdsCode',
+      odsCode: destinationOdsCode,
       attachments: mockRequestBody.coreEhr.attachments,
       external_attachments: [externalAttachmentWithoutTitle, externalAttachmentWithoutTitle]
     });

--- a/src/api/ehr-out/__tests__/send-core-message.test.js
+++ b/src/api/ehr-out/__tests__/send-core-message.test.js
@@ -16,7 +16,7 @@ jest.mock('../../../services/mhs/mhs-attachments-wrangler');
 jest.mock('../../../config', () => ({
   initializeConfig: jest.fn().mockReturnValue({
     consumerApiKeys: { TEST_USER: 'correct-key' },
-    deductionsOdsCode: 'repo_ods_code'
+    repoOdsCode: 'repo_ods_code'
   })
 }));
 

--- a/src/api/ehr-out/__tests__/send-fragment-message.test.js
+++ b/src/api/ehr-out/__tests__/send-fragment-message.test.js
@@ -16,7 +16,7 @@ jest.mock('../../../services/fhir/sds-fhir-client');
 jest.mock('../../../config', () => ({
   initializeConfig: jest.fn().mockReturnValue({
     consumerApiKeys: { TEST_USER: 'correct-key' },
-    deductionsOdsCode: 'test_odscode'
+    repoOdsCode: 'test_odscode'
   })
 }));
 jest.mock('../../../services/mhs/mhs-attachments-wrangler');

--- a/src/api/ehr-out/__tests__/send-fragment-message.test.js
+++ b/src/api/ehr-out/__tests__/send-fragment-message.test.js
@@ -16,7 +16,7 @@ jest.mock('../../../services/fhir/sds-fhir-client');
 jest.mock('../../../config', () => ({
   initializeConfig: jest.fn().mockReturnValue({
     consumerApiKeys: { TEST_USER: 'correct-key' },
-    repoOdsCode: 'test_odscode'
+    repoOdsCode: 'repo_ods_code'
   })
 }));
 jest.mock('../../../services/mhs/mhs-attachments-wrangler');

--- a/src/api/ehr-out/send-core-message.js
+++ b/src/api/ehr-out/send-core-message.js
@@ -36,7 +36,8 @@ export const sendCoreMessage = async (req, res) => {
       payload,
       ehrRequestId,
       receivingPracticeAsid,
-      repositoryOdsCode
+      repositoryOdsCode,
+      odsCode
     );
 
     const { attachments, external_attachments } = await wrangleAttachments(coreEhr);

--- a/src/api/ehr-out/send-core-message.js
+++ b/src/api/ehr-out/send-core-message.js
@@ -22,7 +22,7 @@ export const sendCoreMessage = async (req, res) => {
   const { payload } = coreEhr;
   const interactionId = 'RCMR_IN030000UK06';
   const serviceId = `urn:nhs:names:services:gp2gp:${interactionId}`;
-  const repositoryOdsCode = initializeConfig().deductionsOdsCode;
+  const repositoryOdsCode = initializeConfig().repoOdsCode;
   setCurrentSpanAttributes({ conversationId });
 
   try {

--- a/src/api/health-record-requests/__tests__/send-continue-message.test.js
+++ b/src/api/health-record-requests/__tests__/send-continue-message.test.js
@@ -15,10 +15,10 @@ jest.mock('../../../services/mhs/mhs-outbound-client');
 
 describe('sendContinueMessage', () => {
   const authorizationKeys = 'correct-key';
-  const deductionsAsid = '20000000890';
+  const repoAsid = '20000000890';
   initializeConfig.mockReturnValue({
     consumerApiKeys: { TEST_USER: authorizationKeys },
-    deductionsAsid: deductionsAsid
+    repoAsid: repoAsid
   });
 
   const serviceId = 'urn:nhs:names:services:gp2gp:COPC_IN000001UK01';
@@ -39,7 +39,7 @@ describe('sendContinueMessage', () => {
     const generateContinueRequestInputValues = {
       messageId,
       receivingAsid: gpReceivingAsid,
-      sendingAsid: deductionsAsid,
+      sendingAsid: repoAsid,
       ehrExtractMessageId,
       gpOdsCode
     };

--- a/src/api/health-record-requests/send-continue-message.js
+++ b/src/api/health-record-requests/send-continue-message.js
@@ -28,7 +28,7 @@ export const sendContinueMessage = async (req, res) => {
     const message = await generateContinueRequest({
       messageId,
       receivingAsid: practiceAsid,
-      sendingAsid: config.deductionsAsid,
+      sendingAsid: config.repoAsid,
       ehrExtractMessageId: ehrExtractMessageId.toUpperCase(),
       gpOdsCode
     });

--- a/src/api/patient-demographics/__tests__/pds-retrieval.test.js
+++ b/src/api/patient-demographics/__tests__/pds-retrieval.test.js
@@ -11,7 +11,7 @@ jest.mock('../../../config/logging');
 jest.mock('../../../config/', () => ({
   initializeConfig: jest.fn().mockReturnValue({
     pdsAsid: 'pdsAsid',
-    deductionsAsid: 'deductionsAsid',
+    repoAsid: 'repoAsid',
     spineOrgCode: 'code'
   })
 }));

--- a/src/api/patient-demographics/__tests__/pds-update.test.js
+++ b/src/api/patient-demographics/__tests__/pds-update.test.js
@@ -26,7 +26,7 @@ describe('POST /patient-demographics/:nhsNumber', () => {
     initializeConfig.mockReturnValue({
       pdsAsid: 'pdsAsid',
       repoAsid: 'repoAsid',
-      repoOdsCode: 'deductionsOds',
+      repoOdsCode: 'repoOdsCode',
       nhsNumberPrefix: '944'
     });
 

--- a/src/api/patient-demographics/__tests__/pds-update.test.js
+++ b/src/api/patient-demographics/__tests__/pds-update.test.js
@@ -25,8 +25,8 @@ describe('POST /patient-demographics/:nhsNumber', () => {
   beforeEach(() => {
     initializeConfig.mockReturnValue({
       pdsAsid: 'pdsAsid',
-      deductionsAsid: 'deductionsAsid',
-      deductionsOdsCode: 'deductionsOds',
+      repoAsid: 'repoAsid',
+      repoOdsCode: 'deductionsOds',
       nhsNumberPrefix: '944'
     });
 
@@ -138,7 +138,7 @@ describe('POST /patient-demographics/:nhsNumber', () => {
           id: mockUUID,
           timestamp: fakeDateNow,
           receivingService: { asid: 'pdsAsid' },
-          sendingService: { asid: 'deductionsAsid' },
+          sendingService: { asid: 'repoAsid' },
           newOdsCode: '12345',
           patient: {
             nhsNumber: '9442964410',

--- a/src/api/patient-demographics/pds-retrieval.js
+++ b/src/api/patient-demographics/pds-retrieval.js
@@ -29,7 +29,7 @@ export const pdsRetrieval = async (req, res, next) => {
       id: conversationId,
       timestamp,
       receivingService: { asid: config.pdsAsid },
-      sendingService: { asid: config.deductionsAsid },
+      sendingService: { asid: config.repoAsid },
       patient: { nhsNumber: req.params.nhsNumber }
     });
 

--- a/src/api/patient-demographics/pds-update.js
+++ b/src/api/patient-demographics/pds-update.js
@@ -25,7 +25,7 @@ export const pdsUpdateValidation = [
 ];
 
 export const pdsUpdate = async (req, res, next) => {
-  const { deductionsAsid, pdsAsid, nhsNumberPrefix } = initializeConfig();
+  const { repoAsid, pdsAsid, nhsNumberPrefix } = initializeConfig();
   const { conversationId, newOdsCode, pdsId, serialChangeNumber } = req.body;
   const { nhsNumber } = req.params;
   const timestamp = dateFormat(Date.now(), 'yyyymmddHHMMss');
@@ -49,7 +49,7 @@ export const pdsUpdate = async (req, res, next) => {
       id: conversationId,
       timestamp,
       receivingService: { asid: pdsAsid },
-      sendingService: { asid: deductionsAsid },
+      sendingService: { asid: repoAsid },
       newOdsCode: newOdsCode,
       patient: {
         nhsNumber: nhsNumber,

--- a/src/config/__tests__/config.test.js
+++ b/src/config/__tests__/config.test.js
@@ -14,7 +14,7 @@ describe('config', () => {
     });
   });
 
-  describe('deductionsAsid', () => {
+  describe('repoAsid', () => {
     afterEach(() => {
       process.env.GP2GP_MESSENGER_REPOSITORY_ASID = originalEnv.GP2GP_MESSENGER_REPOSITORY_ASID;
     });
@@ -22,11 +22,11 @@ describe('config', () => {
     it('should return 200000001161 when GP2GP_MESSENGER_REPOSITORY_ASID is not set', () => {
       if (process.env.GP2GP_MESSENGER_REPOSITORY_ASID)
         delete process.env.GP2GP_MESSENGER_REPOSITORY_ASID;
-      expect(initializeConfig().deductionsAsid).toEqual('200000001161');
+      expect(initializeConfig().repoAsid).toEqual('200000001161');
     });
   });
 
-  describe('deductionsOdsCode', () => {
+  describe('repoOdsCode', () => {
     afterEach(() => {
       process.env.GP2GP_MESSENGER_REPOSITORY_ODS_CODE =
         originalEnv.GP2GP_MESSENGER_REPOSITORY_ODS_CODE;
@@ -35,7 +35,7 @@ describe('config', () => {
     it('should return B86041 when GP2GP_MESSENGER_REPOSITORY_ODS_CODE is not set', () => {
       if (process.env.GP2GP_MESSENGER_REPOSITORY_ODS_CODE)
         delete process.env.GP2GP_MESSENGER_REPOSITORY_ODS_CODE;
-      expect(initializeConfig().deductionsOdsCode).toEqual('B86041');
+      expect(initializeConfig().repoOdsCode).toEqual('B86041');
     });
   });
 
@@ -50,8 +50,8 @@ describe('config', () => {
       });
 
       it('should map config with process.env values if set', () => {
-        process.env.GP2GP_MESSENGER_REPOSITORY_ASID = 'deductionsAsid';
-        process.env.GP2GP_MESSENGER_REPOSITORY_ODS_CODE = 'deductionsOdsCode';
+        process.env.GP2GP_MESSENGER_REPOSITORY_ASID = 'repoAsid';
+        process.env.GP2GP_MESSENGER_REPOSITORY_ODS_CODE = 'REPO_ODS_CODE';
         process.env.PDS_ASID = 'pdsAsid';
         process.env.GP2GP_MESSENGER_MHS_OUTBOUND_URL = 'mhsOutboundUrl';
         process.env.NHS_ENVIRONMENT = 'nhsEnvironment';
@@ -59,8 +59,8 @@ describe('config', () => {
 
         expect(initializeConfig()).toEqual(
           expect.objectContaining({
-            deductionsAsid: 'deductionsAsid',
-            deductionsOdsCode: 'DEDUCTIONSODSCODE',
+            repoAsid: 'repoAsid',
+            repoOdsCode: 'REPO_ODS_CODE',
             pdsAsid: 'pdsAsid',
             mhsOutboundUrl: 'mhsOutboundUrl',
             nhsEnvironment: 'nhsEnvironment'

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,8 +1,8 @@
 export const portNumber = 3000;
 
 export const initializeConfig = () => ({
-  deductionsAsid: process.env.GP2GP_MESSENGER_REPOSITORY_ASID || '200000001161',
-  deductionsOdsCode: (process.env.GP2GP_MESSENGER_REPOSITORY_ODS_CODE || 'B86041').toUpperCase(),
+  repoAsid: process.env.GP2GP_MESSENGER_REPOSITORY_ASID || '200000001161',
+  repoOdsCode: (process.env.GP2GP_MESSENGER_REPOSITORY_ODS_CODE || 'B86041').toUpperCase(),
   pdsAsid: process.env.PDS_ASID,
   mhsOutboundUrl: process.env.GP2GP_MESSENGER_MHS_OUTBOUND_URL,
   nhsEnvironment: process.env.NHS_ENVIRONMENT || 'local',

--- a/src/services/mhs/__tests__/mhs-outbound-client.test.js
+++ b/src/services/mhs/__tests__/mhs-outbound-client.test.js
@@ -34,7 +34,7 @@ describe('mhs-outbound-client', () => {
   };
   const axiosBody = { payload: message };
   initializeConfig.mockReturnValue({
-    deductionsAsid: testData.mhs.asid,
+    repoAsid: testData.mhs.asid,
     mhsOutboundUrl: url,
     spineOdsCode: 'YES',
     pdsAsid: '928942012545'

--- a/src/services/mhs/mhs-outbound-client.js
+++ b/src/services/mhs/mhs-outbound-client.js
@@ -61,7 +61,7 @@ export const sendMessage = async ({
       'Interaction-ID': interactionId,
       'Correlation-Id': conversationId,
       'Ods-Code': odsCode,
-      'from-asid': config.deductionsAsid,
+      'from-asid': config.repoAsid,
       'wait-for-response': false
     }
   };

--- a/src/services/parser/message/__tests__/data/templateEhrExtract
+++ b/src/services/parser/message/__tests__/data/templateEhrExtract
@@ -49,7 +49,7 @@
                 <destination typeCode="DST">
                     <AgentOrgSDS classCode="AGNT">
                         <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
-                            <id extension="C88653" root="1.2.826.0.1285.0.1.10"/>
+                            <id extension="${destOdsCode}" root="1.2.826.0.1285.0.1.10"/>
                         </agentOrganizationSDS>
                     </AgentOrgSDS>
                 </destination>

--- a/src/services/parser/message/__tests__/update-extract-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-extract-for-sending.test.js
@@ -13,10 +13,9 @@ describe('updateExtractForSending', () => {
   const OLD_DEST_ODS_CODE = 'OLD-DESTINATION-ODS-CODE';
 
   const NEW_SENDING_ASID = '200000001161';
-  const NEW_RECEIVING_ASID = '200000001162'
+  const NEW_RECEIVING_ASID = '200000001162';
   const NEW_AUTHOR_ODS_CODE = 'NEW-AUTHOR-ODS-CODE';
   const NEW_DEST_ODS_CODE = 'NEW-DESTINATION-ODS-CODE';
-
 
   const templateEhrExtract = (
     receivingAsid,

--- a/src/services/parser/message/__tests__/update-extract-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-extract-for-sending.test.js
@@ -42,7 +42,7 @@ describe('updateExtractForSending', () => {
     );
   };
 
-  it('should use the new ehr request id, sending asid and receiving asid - as well as overriding author with sending ods code as TPP uses it for COPC continue message destination', async () => {
+  it('should update sender and receiver ASID codes, ODS codes and EHR Request ID in EHR Core', async () => {
     // given
     const originalEhrExtract = buildInputEhrExtract();
     const ehrRequestId = v4();

--- a/src/services/parser/message/__tests__/update-extract-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-extract-for-sending.test.js
@@ -8,18 +8,21 @@ export const templateEhrExtract = (
   receivingAsid,
   sendingAsid,
   priorEhrRequestId,
-  authorOdsCode
+  authorOdsCode,
+  destOdsCode
 ) => {
   const template = readFileSync(path.join(__dirname, 'data', 'templateEhrExtract'), 'utf-8');
   return template
     .replaceAll('${receivingAsid}', receivingAsid)
     .replaceAll('${sendingAsid}', sendingAsid)
     .replaceAll('${priorEhrRequestId}', priorEhrRequestId)
-    .replaceAll('${authorOdsCode}', authorOdsCode);
+    .replaceAll('${authorOdsCode}', authorOdsCode)
+    .replaceAll('${destOdsCode}', destOdsCode);
 };
 
 describe('updateExtractForSending', () => {
   it('should use the new ehr request id, sending asid and receiving asid - as well as overriding author with sending ods code as TPP uses it for COPC continue message destination', async () => {
+    // given
     const oldSendingAsid = '200000000149';
     const oldReceivingAsid = '200000001161';
     const oldEhrRequestId = 'BBBBA01A-A9D1-A411-F824-9F7A00A33757';
@@ -27,7 +30,8 @@ describe('updateExtractForSending', () => {
       oldReceivingAsid,
       oldSendingAsid,
       oldEhrRequestId,
-      'some-old-author-ods-code'
+      'old-author-ods-code',
+      'old-destination-ods-code'
     );
 
     const newSendingAsid = '200000001161';
@@ -37,16 +41,20 @@ describe('updateExtractForSending', () => {
       newReceivingAsid,
       newSendingAsid,
       ehrRequestId,
-      'sending-ods-code'
+      'sending-ods-code',
+      'destination-ods-code'
     );
 
+    // when
     const newEhrExtract = await updateExtractForSending(
       originalEhrExtract,
       ehrRequestId,
       newReceivingAsid,
-      'sending-ods-code'
+      'sending-ods-code',
+      'destination-ods-code'
     );
 
+    // then
     const parsedNewEhrExtract = await new XmlParser().parse(newEhrExtract);
     const parsedExpectedEhrExtract = await new XmlParser().parse(expectedEhrExtract);
     expect(parsedNewEhrExtract).toEqual(parsedExpectedEhrExtract);
@@ -61,7 +69,8 @@ describe('updateExtractForSending', () => {
       oldReceivingAsid,
       oldSendingAsid,
       oldEhrRequestId,
-      'some-old-author-ods-code'
+      'old-author-ods-code',
+      'old-destination-ods-code'
     );
 
     // manually add some escaped special characters to the ehr extract
@@ -79,7 +88,8 @@ describe('updateExtractForSending', () => {
       ehrExtractWithSpecialChars,
       ehrRequestId,
       newReceivingAsid,
-      'sending-ods-code'
+      'sending-ods-code',
+      'destination-ods-code'
     );
 
     expect(newEhrExtract.includes(replacedText)).toBe(true);

--- a/src/services/parser/message/__tests__/update-extract-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-extract-for-sending.test.js
@@ -4,54 +4,65 @@ import * as path from 'path';
 import { v4 } from 'uuid';
 import { XmlParser } from '../../xml-parser/xml-parser';
 
-export const templateEhrExtract = (
-  receivingAsid,
-  sendingAsid,
-  priorEhrRequestId,
-  authorOdsCode,
-  destOdsCode
-) => {
-  const template = readFileSync(path.join(__dirname, 'data', 'templateEhrExtract'), 'utf-8');
-  return template
-    .replaceAll('${receivingAsid}', receivingAsid)
-    .replaceAll('${sendingAsid}', sendingAsid)
-    .replaceAll('${priorEhrRequestId}', priorEhrRequestId)
-    .replaceAll('${authorOdsCode}', authorOdsCode)
-    .replaceAll('${destOdsCode}', destOdsCode);
-};
-
 describe('updateExtractForSending', () => {
+  // Constants for test
+  const OLD_RECEIVING_ASID = '200000001161';
+  const OLD_SENDING_ASID = '200000000149';
+  const OLD_EHR_REQUEST_ID = v4();
+  const OLD_AUTHOR_ODS_CODE = 'OLD-AUTHOR-ODS-CODE';
+  const OLD_DEST_ODS_CODE = 'OLD-DESTINATION-ODS-CODE';
+
+  const NEW_SENDING_ASID = '200000001161';
+  const NEW_RECEIVING_ASID = '200000001162'
+  const NEW_AUTHOR_ODS_CODE = 'NEW-AUTHOR-ODS-CODE';
+  const NEW_DEST_ODS_CODE = 'NEW-DESTINATION-ODS-CODE';
+
+
+  const templateEhrExtract = (
+    receivingAsid,
+    sendingAsid,
+    priorEhrRequestId,
+    authorOdsCode,
+    destOdsCode
+  ) => {
+    const template = readFileSync(path.join(__dirname, 'data', 'templateEhrExtract'), 'utf-8');
+    return template
+      .replaceAll('${receivingAsid}', receivingAsid)
+      .replaceAll('${sendingAsid}', sendingAsid)
+      .replaceAll('${priorEhrRequestId}', priorEhrRequestId)
+      .replaceAll('${authorOdsCode}', authorOdsCode)
+      .replaceAll('${destOdsCode}', destOdsCode);
+  };
+  const buildInputEhrExtract = () => {
+    return templateEhrExtract(
+      OLD_RECEIVING_ASID,
+      OLD_SENDING_ASID,
+      OLD_EHR_REQUEST_ID,
+      OLD_AUTHOR_ODS_CODE,
+      OLD_DEST_ODS_CODE
+    );
+  };
+
   it('should use the new ehr request id, sending asid and receiving asid - as well as overriding author with sending ods code as TPP uses it for COPC continue message destination', async () => {
     // given
-    const oldSendingAsid = '200000000149';
-    const oldReceivingAsid = '200000001161';
-    const oldEhrRequestId = 'BBBBA01A-A9D1-A411-F824-9F7A00A33757';
-    const originalEhrExtract = templateEhrExtract(
-      oldReceivingAsid,
-      oldSendingAsid,
-      oldEhrRequestId,
-      'old-author-ods-code',
-      'old-destination-ods-code'
-    );
-
-    const newSendingAsid = '200000001161';
-    const newReceivingAsid = '200000001162';
+    const originalEhrExtract = buildInputEhrExtract();
     const ehrRequestId = v4();
+
     const expectedEhrExtract = templateEhrExtract(
-      newReceivingAsid,
-      newSendingAsid,
+      NEW_RECEIVING_ASID,
+      NEW_SENDING_ASID,
       ehrRequestId,
-      'sending-ods-code',
-      'destination-ods-code'
+      NEW_AUTHOR_ODS_CODE,
+      NEW_DEST_ODS_CODE
     );
 
     // when
     const newEhrExtract = await updateExtractForSending(
       originalEhrExtract,
       ehrRequestId,
-      newReceivingAsid,
-      'sending-ods-code',
-      'destination-ods-code'
+      NEW_RECEIVING_ASID,
+      NEW_AUTHOR_ODS_CODE,
+      NEW_DEST_ODS_CODE
     );
 
     // then
@@ -62,16 +73,7 @@ describe('updateExtractForSending', () => {
 
   it('should keep escaped special characters (linebreak, apostrophes, quotation marks) unchanged', async () => {
     // given
-    const oldSendingAsid = '200000000149';
-    const oldReceivingAsid = '200000001161';
-    const oldEhrRequestId = 'BBBBA01A-A9D1-A411-F824-9F7A00A33757';
-    const originalEhrExtract = templateEhrExtract(
-      oldReceivingAsid,
-      oldSendingAsid,
-      oldEhrRequestId,
-      'old-author-ods-code',
-      'old-destination-ods-code'
-    );
+    const originalEhrExtract = buildInputEhrExtract();
 
     // manually add some escaped special characters to the ehr extract
     const replacedText =
@@ -80,18 +82,19 @@ describe('updateExtractForSending', () => {
       'Drinking status on eventdate: Current drinker',
       replacedText
     );
-
-    const newReceivingAsid = '200000001162';
     const ehrRequestId = v4();
 
+    // when
     const newEhrExtract = await updateExtractForSending(
       ehrExtractWithSpecialChars,
       ehrRequestId,
-      newReceivingAsid,
-      'sending-ods-code',
-      'destination-ods-code'
+      NEW_RECEIVING_ASID,
+      NEW_AUTHOR_ODS_CODE,
+      NEW_DEST_ODS_CODE
     );
 
+    // then
+    // expect that the special chars are still in the updated ehr extract
     expect(newEhrExtract.includes(replacedText)).toBe(true);
   });
 });

--- a/src/services/parser/message/__tests__/update-fragment-for-sending.test.js
+++ b/src/services/parser/message/__tests__/update-fragment-for-sending.test.js
@@ -10,8 +10,8 @@ describe('updateFragmentForSending', () => {
     const sendingAsid = 'new-sending-asid';
     const sendingOdsCode = 'new-sending-ods-code';
     initializeConfig.mockReturnValue({
-      deductionsAsid: sendingAsid,
-      deductionsOdsCode: sendingOdsCode
+      repoAsid: sendingAsid,
+      repoOdsCode: sendingOdsCode
     });
     const originalFragment = templateLargeEhrFragmentTestMessage(
       'old-message-id',

--- a/src/services/parser/message/update-extract-for-sending.js
+++ b/src/services/parser/message/update-extract-for-sending.js
@@ -28,7 +28,10 @@ export const updateExtractForSending = async (
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract, sendingOdsCode);
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract.component.ehrFolder, sendingOdsCode);
 
-  updateIdExtension(controlActEvent.subject.EhrExtract.destination.AgentOrgSDS.agentOrganizationSDS, destinationOdsCode)
+  updateIdExtension(
+    controlActEvent.subject.EhrExtract.destination.AgentOrgSDS.agentOrganizationSDS,
+    destinationOdsCode
+  );
 
   return jsObjectToXmlString(parsedEhr);
 };

--- a/src/services/parser/message/update-extract-for-sending.js
+++ b/src/services/parser/message/update-extract-for-sending.js
@@ -15,7 +15,7 @@ export const updateExtractForSending = async (
   const config = initializeConfig();
   const parsedEhr = await xmlStringToJsObject(ehrExtract);
 
-  const sendingAsid = config.deductionsAsid;
+  const sendingAsid = config.repoAsid;
 
   const rcmrUK06 = parsedEhr.RCMR_IN030000UK06;
   const controlActEvent = rcmrUK06.ControlActEvent;

--- a/src/services/parser/message/update-extract-for-sending.js
+++ b/src/services/parser/message/update-extract-for-sending.js
@@ -9,7 +9,8 @@ export const updateExtractForSending = async (
   ehrExtract,
   ehrRequestId,
   receivingAsid,
-  sendingOdsCode
+  sendingOdsCode,
+  destinationOdsCode
 ) => {
   const config = initializeConfig();
   const parsedEhr = await xmlStringToJsObject(ehrExtract);
@@ -26,6 +27,8 @@ export const updateExtractForSending = async (
 
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract, sendingOdsCode);
   updateAuthorOdsCode(controlActEvent.subject.EhrExtract.component.ehrFolder, sendingOdsCode);
+
+  updateIdExtension(controlActEvent.subject.EhrExtract.destination.AgentOrgSDS.agentOrganizationSDS, destinationOdsCode)
 
   return jsObjectToXmlString(parsedEhr);
 };

--- a/src/services/parser/message/update-fragment-for-sending.js
+++ b/src/services/parser/message/update-fragment-for-sending.js
@@ -13,8 +13,8 @@ export async function updateFragmentForSending(
   recipientOdsCode
 ) {
   const config = initializeConfig();
-  const sendingAsid = config.deductionsAsid;
-  const sendingOdsCode = config.deductionsOdsCode;
+  const sendingAsid = config.repoAsid;
+  const sendingOdsCode = config.repoOdsCode;
 
   const payloadXml = xmlStringToJsObject(fragmentPayload);
 

--- a/src/templates/__tests__/generate-continue-request.test.js
+++ b/src/templates/__tests__/generate-continue-request.test.js
@@ -13,7 +13,7 @@ describe('generateContinueRequest', () => {
 
   it('should return the continue request template with correct values', () => {
     const timestamp = dateFormat(Date.now(), 'yyyymmddHHMMss');
-    const repoOdsCode = initializeConfig().deductionsOdsCode;
+    const repoOdsCode = initializeConfig().repoOdsCode;
     const returnValue = generateContinueRequest({
       messageId,
       receivingAsid,

--- a/src/templates/generate-continue-request.js
+++ b/src/templates/generate-continue-request.js
@@ -9,7 +9,7 @@ export const generateContinueRequest = ({
   ehrExtractMessageId,
   gpOdsCode
 }) => {
-  const { deductionsOdsCode } = initializeConfig();
+  const { repoOdsCode } = initializeConfig();
   const timestamp = dateFormat(Date.now(), 'yyyymmddHHMMss');
   const inputObject = {
     id: messageId,
@@ -18,7 +18,7 @@ export const generateContinueRequest = ({
     sendingAsid,
     ehrExtractMessageId,
     gpOdsCode,
-    repoOdsCode: deductionsOdsCode
+    repoOdsCode: repoOdsCode
   };
   checkTemplateArguments(inputObject);
   return continueRequest(inputObject);


### PR DESCRIPTION
- Amend updateExtractForSending to also update destination ODS code
(Before this PR, it update the sender ASID code, destination ASID code and sender ODS code, but not the destination ODS code)
- Modify existing test to check that destination ODS code is updated
- Refactor the unit test for DRY
- Rename the variable `deductionsOdsCode` to `repoOdsCode` for clearer meaning and differentiate from `destinationOdsCode`. Same for `deductionAsid` as well.