### PR TITLE
[PRM-221] Improved safe list validation and nhs number prefix enforcement

### DIFF
--- a/src/api/health-record-requests/__tests__/health-record-requests.test.js
+++ b/src/api/health-record-requests/__tests__/health-record-requests.test.js
@@ -128,31 +128,12 @@ describe('POST /health-record-requests/:nhsNumber', () => {
   });
 
   describe('NHS Number prefix checks', () => {
-    // TODO: REMOVE THESE TESTS
-    // it('should not allow a health record request and return 404 when nhs number prefix is empty', async () => {
-    //   initializeConfig.mockReturnValueOnce({ nhsNumberPrefix: '' });
-    //   const res = await request(app).post('/health-record-requests/1234567890').send(body);
-    //   expect(res.status).toBe(422);
-    //   expect(logWarning).toHaveBeenCalledWith(
-    //     'Health record request failed as no nhs number prefix env variable has been set'
-    //   );
-    // });
-    //
-    // it('should not allow a health record request and return 404 when nhs number prefix is undefined', async () => {
-    //   initializeConfig.mockReturnValueOnce({});
-    //   const res = await request(app).post('/health-record-requests/1234567890').send(body);
-    //   expect(res.status).toBe(422);
-    //   expect(logWarning).toHaveBeenCalledWith(
-    //     'Health record request failed as no nhs number prefix env variable has been set'
-    //   );
-    // });
-
     it('should not allow a health record request when the nhs number does not start with the expected prefix', async () => {
       initializeConfig.mockReturnValueOnce({ nhsNumberPrefix: '999' });
       const res = await request(app).post('/health-record-requests/1234567890').send(body);
       expect(res.status).toBe(422);
       expect(logWarning).toHaveBeenCalledWith(
-        'Health record request failed as nhs number does not start with expected prefix: 999'
+        'Health record request failed as nhs number does not start with enforced prefix: 999'
       );
     });
 


### PR DESCRIPTION
I've also included a few clean up tasks such as formatting to make the logic more concise and a change to odsCodeNotInSafeList so it now is just odsCodeInSafeList and does a positive check for the presence of the ODS code and not a negative check for the absence of it. This is reflected in line 45 where it is called.